### PR TITLE
Upgrade Apache Commons Collection to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ project('solr-hadoop-core') {
 
     testCompile 'com.carrotsearch.randomizedtesting:junit4-ant:1.4.0'
     testCompile "org.apache.lucene:lucene-analyzers-common:${solrVersion}"
-    testCompile 'commons-collections:commons-collections:3.2.1'
+    testCompile 'commons-collections:commons-collections:3.2.2'
 
     testCompile "org.apache.solr:solr-test-framework:${solrVersion}"
     testCompile 'org.apache.mrunit:mrunit:1.0.0:hadoop2@jar'


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/