### PR TITLE
LWSHADOOP-584: Hadoop projects improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,6 +52,23 @@ If you rebuild the job jar at a later time (to take advantage of updates), remem
 
 NOTE: The Gradle task will also produce `{packageUser}-hadoop-tika-{connectorVersion}.jar` located in the `solr-hadoop-common/solr-hadoop-tika/build/libs` directory. This jar will be needed if you use the `-Dlw.tika.process` parameter described below. Using Tika is recommended when when using the DirectoryIngestMapper or the ZipIngestMapper.
 
+=== Troubleshooting
+
+If GitHub + SSH is not configured the following exception will be thrown:
+
+[source]
+----
+    Cloning into 'solr-hadoop-common'...
+    Permission denied (publickey).
+    fatal: Could not read from remote repository.
+
+    Please make sure you have the correct access rights
+    and the repository exists.
+    fatal: clone of 'git@github.com:LucidWorks/solr-hadoop-common.git' into submodule path 'solr-hadoop-common' failed
+----
+
+Use the next tutorial to fix the exception: https://help.github.com/articles/generating-an-ssh-key/
+
 // end::build[]
 
 // tag::how-to-use[]

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,11 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '1.2.2'
+  id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.9'
+    gradleVersion = '3.0'
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ subprojects {
       }
     }
 
+    test {
+      reports.html.destination = file("$buildDir/reports/tests")
+    }
+
     jacocoTestReport {
       reports {
         xml.enabled false

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ subprojects {
 
     test {
       reports.html.destination = file("$buildDir/reports/tests")
+      reports.junitXml.destination = file("$buildDir/test-results")
     }
 
     jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ plugins {
   id 'com.github.johnrengelman.shadow' version '1.2.2'
 }
 
+task wrapper(type: Wrapper) {
+    gradleVersion = '2.9'
+}
 
 ext {
   publishedProjects = subprojects - project(':solr-hadoop-common')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip


### PR DESCRIPTION
# Related issues:

- LWSHADOOP-584: Build hadoop related projects
- LWSHADOOP-588: Update gradle version of hadoop related projects

# Changes:

- Add "Troubleshooting" to "How to Build" section
- Add wrapper task to gradle build
- Upgrade gradle to 3.0