### PR TITLE
LWSHADOOP-614 Change document type in FusionClient

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.lucidworks.hadoop
-version=2.2.5
+version=2.2.6
 
 solrVersion=5.5.2
 hadoop2Version=2.7.1


### PR DESCRIPTION
PR Description

- The document type in FusionClient was updated from **application/json** to **application/vnd.lucidworks-document**