### PR TITLE
LWSHADOOP-592: add support for unicode delimiters.

### DIFF
--- a/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/IngestJobInit.java
+++ b/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/IngestJobInit.java
@@ -61,6 +61,7 @@ public class IngestJobInit extends SolrCloudClusterSupport {
 
   @Before
   public void setUp() throws Exception {
+    conf.clear();
     removeAllDocs();
     clearOutput();
   }

--- a/solr-hadoop-core/src/test/resources/csv/LWS592.csv
+++ b/solr-hadoop-core/src/test/resources/csv/LWS592.csv
@@ -1,0 +1,2 @@
+1johnNZ
+2MohanUS


### PR DESCRIPTION
Add support for unicode delimiters
Encode 64 delimiters in Hadoop Job Configuration