### PR TITLE
LWSHADOOP-615: add fail on error variable to Fusion client, update co…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.lucidworks.hadoop
-version=2.2.6
+version=2.2.7
 
 solrVersion=5.5.2
 hadoop2Version=2.7.1


### PR DESCRIPTION
* Add fail on error variable to Fusion client.
* if false the job jar will not fail even though some documents will not be indexed. 