### PR TITLE
LWSHADOOP-517: Uncomment IngestJobTest

### DIFF
--- a/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/IngestJobTest.java
+++ b/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/IngestJobTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.fail;
  **/
 public class IngestJobTest extends IngestJobInit {
 
-  @Ignore
   @Test
   public void testCSV() throws Exception {
     Path input = new Path(tempDir, "foo.csv");


### PR DESCRIPTION
A recent commit fixed a bug causing sporadic IngestJobTest failures.
With this bug fixed, IngestJobTest can be uncommented and added back
to test runs.