### PR TITLE
LWSHADOOP-703: Use minicluster in CSVIngestMapperTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,14 @@ project('solr-hadoop-core') {
 
     testCompile 'org.apache.mrunit:mrunit:1.0.0:hadoop2@jar'
 
+    hadoop2TestCompile("org.apache.hadoop:hadoop-minicluster:${hadoop2Version}") {
+      exclude group: "org.apache.zookeeper", module: "zookeeper"
+      exclude group: "org.apache.hadoop", module: "hadoop-mapreduce-client-jobclient"
+    }
+    hadoop3TestCompile("org.apache.hadoop:hadoop-minicluster:${hadoop3Version}") {
+      exclude group: "org.apache.zookeeper", module: "zookeeper"
+      exclude group: "org.apache.hadoop", module: "hadoop-mapreduce-client-jobclient"
+    }
   }
 }
 

--- a/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/BaseMiniClusterTestCase.java
+++ b/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/BaseMiniClusterTestCase.java
@@ -1,0 +1,162 @@
+package com.lucidworks.hadoop.ingest;
+
+import com.lucidworks.hadoop.io.LWDocumentWritable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileOutputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.test.PathUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BaseMiniClusterTestCase {
+
+    protected static final Path INPUT_DIRECTORY_PATH = new Path("testing/data/input");
+    protected static final Path OUTPUT_DIRECTORY_PATH = new Path("testing/data/output");
+    protected static final String CLUSTER_NAME = "cluster1";
+    protected static final File testDataPath = new File(PathUtils.getTestDir(BaseMiniClusterTestCase.class), "miniclusters");
+
+    protected static Configuration clusterConf;
+    protected static MiniDFSCluster cluster;
+    protected static FileSystem fs;
+
+    protected List<String> jobInput;
+
+    @BeforeClass
+    public static void setUpCluster() throws Exception {
+        System.clearProperty(MiniDFSCluster.PROP_TEST_BUILD_DATA);
+        clusterConf = new HdfsConfiguration();
+
+        File testDataCluster1 = new File(testDataPath, CLUSTER_NAME);
+        String c1Path = testDataCluster1.getAbsolutePath();
+        clusterConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, c1Path);
+        cluster = new MiniDFSCluster.Builder(clusterConf).build();
+        cluster.waitClusterUp();
+
+        fs = FileSystem.get(clusterConf);
+    }
+
+    @AfterClass
+    public static void tearDownCluster() throws Exception {
+        Path dataDir = new Path(testDataPath.getParentFile().getParentFile().getParent());
+        fs.delete(dataDir, true);
+        File rootTestFile = new File(testDataPath.getParentFile().getParentFile().getParent());
+        String rootTestDir = rootTestFile.getAbsolutePath();
+        Path rootTestPath = new Path(rootTestDir);
+        LocalFileSystem localFileSystem = FileSystem.getLocal(clusterConf);
+        localFileSystem.delete(rootTestPath, true);
+        cluster.shutdown();
+    }
+
+
+    @Before
+    public void setUp() throws Exception {
+        fs.delete(INPUT_DIRECTORY_PATH, true);
+        fs.delete(OUTPUT_DIRECTORY_PATH, true);
+
+        jobInput = new ArrayList<>();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        fs.delete(INPUT_DIRECTORY_PATH, true);
+        fs.delete(OUTPUT_DIRECTORY_PATH, true);
+    }
+
+    protected Configuration getBaseConfiguration() {
+        return new HdfsConfiguration(clusterConf);
+    }
+
+    protected Job createJobBasedOnConfiguration(Configuration baseConfiguration, Class mapperClazz) throws Exception{
+        JobConf jobConf = new JobConf(baseConfiguration);
+        jobConf.setMapperClass(mapperClazz);
+        FileInputFormat.addInputPath(jobConf, INPUT_DIRECTORY_PATH);
+        FileOutputFormat.setOutputPath(jobConf, OUTPUT_DIRECTORY_PATH);
+        Job job = Job.getInstance(jobConf);
+        job.setOutputKeyClass(Text.class);
+        job.setOutputValueClass(LWDocumentWritable.class);
+
+        return job;
+    }
+
+    protected void withJobInput(List<String> jobInput) throws IOException {
+        writeHDFSContent(fs, INPUT_DIRECTORY_PATH, "sample.txt", jobInput);
+    }
+
+    protected List<String> runJobSuccessfully(Job job, List<String> input, int expectedLines) throws Exception {
+        fs.delete(INPUT_DIRECTORY_PATH, true);
+        fs.delete(OUTPUT_DIRECTORY_PATH, true);
+
+        withJobInput(input);
+        job.waitForCompletion(true);
+        assertTrue(job.isSuccessful());
+
+        return getJobResults(expectedLines);
+    }
+
+    private void writeHDFSContent(FileSystem fs, Path dir, String fileName, List<String> content) throws IOException {
+        Path newFilePath = new Path(dir, fileName);
+        FSDataOutputStream out = fs.create(newFilePath);
+        for (String line : content){
+            out.writeBytes(line);
+            out.writeBytes("\n");
+        }
+        out.close();
+    }
+
+    protected List<String> getJobResults(int expectedLines) throws Exception {
+        List<String> results = new ArrayList<String>();
+        FileStatus[] fileStatus = fs.listStatus(OUTPUT_DIRECTORY_PATH);
+        for (FileStatus file : fileStatus) {
+            String name = file.getPath().getName();
+            if (name.contains("part-r-00000")){
+                Path filePath = new Path(OUTPUT_DIRECTORY_PATH + "/" + name);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(filePath)));
+                for (int i=0; i < expectedLines; i++){
+                    String line = reader.readLine();
+                    if (line == null){
+                        fail("Expected [" + expectedLines + "] of output but only found [" + i + "]");
+                    }
+                    results.add(line);
+                }
+                assertNull(reader.readLine());
+                reader.close();
+            }
+        }
+        return results;
+    }
+
+    protected String createExpectedDocStrWithFields(String idValue, String ... fields) {
+        if (fields.length % 2 != 0) {
+            fail("Expected field-value String pairs, but received an odd number of String inputs");
+        }
+
+        final StringBuilder sb = new StringBuilder(idValue + "\tLWDocumentWritable{document=SolrInputDocument(fields: [");
+        for (int i = 0; i < fields.length; i+=2) {
+            sb.append(fields[i] + "=" + fields[i+1]);
+            if (i < fields.length - 2) { // if we're not the last field-value pair
+                sb.append(", ");
+            }
+        }
+        sb.append("])}");
+        return sb.toString();
+    }
+}

--- a/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/CSVIngestMapperTest.java
+++ b/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/CSVIngestMapperTest.java
@@ -1,305 +1,233 @@
 package com.lucidworks.hadoop.ingest;
 
-import com.lucidworks.hadoop.io.LWDocument;
-import com.lucidworks.hadoop.io.LWDocumentProvider;
-import com.lucidworks.hadoop.io.LWDocumentWritable;
-import com.lucidworks.hadoop.utils.TestUtils;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.mapreduce.Job;
+import org.junit.Test;
+
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.LongWritable;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mrunit.MapDriver;
-import org.apache.hadoop.mrunit.types.Pair;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import static com.lucidworks.hadoop.utils.ConfigurationKeys.COLLECTION;
 import static com.lucidworks.hadoop.utils.ConfigurationKeys.ZK_CONNECT;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertFalse;
 
-/**
- *
- *
- **/
-public class CSVIngestMapperTest extends BaseIngestMapperTestCase {
+public class CSVIngestMapperTest extends BaseMiniClusterTestCase {
 
-  private MapDriver<LongWritable, Text, Text, LWDocumentWritable> mapDriver;
+    @Test
+    public void testParsesLinesAsIndividualDocuments() throws Exception {
+        jobInput.add("id,bar,junk,zen,hockey"); // Skipped because of first line ignore setting
+        jobInput.add("id-1, The quick brown fox, jumped, head, gretzky, extra");
 
-  @Before
-  public void setUp() throws IOException {
-    CSVIngestMapper mapper = new CSVIngestMapper();
-    mapDriver = new MapDriver<>();
-    mapDriver.setMapper(mapper);
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
 
-    mapDriver.setConfiguration(createConf());
-    Configuration configuration = mapDriver.getConfiguration();
-    configuration.set(COLLECTION, "collection");
-    configuration.set(ZK_CONNECT, "localhost:0000");
-    configuration.set("idField", "id");
-
-    JobConf conf = new JobConf(configuration);
-  }
-
-  @Test
-  public void test() throws Exception {
-    Configuration conf = mapDriver.getConfiguration();
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "true");
-    byte[] delimiterBase64 = Base64.encodeBase64(",".getBytes());
-    conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=bar, 2=junk , 3 = zen ,   4 = hockey");
-
-    LongWritable key = new LongWritable(0);// should be skipped
-    Text value = new Text("id,bar,junk,zen,hockey");// we skip the 0th line
-
-    mapDriver.withInput(key, value);
-    mapDriver.runTest();
-    assertEquals("Should be 0 documents", 0,
-        mapDriver.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
-    key = new LongWritable(1);
-    value = new Text("id-1, The quick brown fox, jumped, head, gretzky, extra");
-    // extra should be mapped to field_5
-    mapDriver.withInput(key, value);
-    mapDriver.withCounter(BaseHadoopIngest.Counters.DOCS_ADDED, 1);
-    LWDocumentWritable val = TestUtils
-        .createLWDocumentWritable("id-1", "bar", "The quick brown fox", "junk", "jumped", "zen",
-            "head", "hockey", "gretzky", "field_5", "extra");
-    mapDriver.withOutput(new Text("id-1"), val);
-    mapDriver.runTest();
-  }
-
-  @Test
-  public void testLWS592() throws Exception {
-    Configuration conf = mapDriver.getConfiguration();
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "true");
-    byte[] delimiterBase64 = Base64.encodeBase64("\u0001".getBytes());
-
-    conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=bar,2=junk");
-
-    LongWritable key = new LongWritable(0);
-    Text value = new Text("idbarjunk"); // values with ctrl + A as delimiters
-
-    mapDriver.withInput(key, value);
-    mapDriver.runTest();
-    assertEquals("Should be 0 documents", 0,
-      mapDriver.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
-    key = new LongWritable(1);
-    value = new Text("id-1The quick brown foxhead"); // values with ctrl + A as delimiters
-    mapDriver.withInput(key, value);
-    mapDriver.withCounter(BaseHadoopIngest.Counters.DOCS_ADDED, 1);
-    LWDocumentWritable val = TestUtils.createLWDocumentWritable("id-1", "bar", "The quick brown fox", "junk", "head");
-    mapDriver.withOutput(new Text("id-1"), val);
-    mapDriver.runTest();
-  }
-
-  @Test
-  public void testDefaultFieldID() throws Exception {
-
-    Configuration conf = mapDriver.getConfiguration();
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "true");
-    byte[] delimiterBase64 = Base64.encodeBase64(",".getBytes());
-    conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
-    // The "id" is in a different position
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=bar, 1=id, 2=junk, 3=zen, 4 = hockey");
-
-    LongWritable key = new LongWritable(0);// should be skipped
-    Text value = new Text("bar, id,junk,zen,hockey");// we skip the 0th line
-
-    mapDriver.withInput(key, value);
-    mapDriver.runTest();
-    assertEquals("Should be 0 documents", 0,
-        mapDriver.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
-    key = new LongWritable(1);
-    value = new Text("The quick brown fox, id-1, jumped, head, gretzky, extra");
-    // extra should be mapped to field_5
-    mapDriver.withInput(key, value);
-    mapDriver.withCounter(BaseHadoopIngest.Counters.DOCS_ADDED, 1);
-    LWDocumentWritable val = TestUtils
-        .createLWDocumentWritable("id-1", "bar", "The quick brown fox", "junk", "jumped", "zen",
-            "head", "hockey", "gretzky", "field_5", "extra");
-    mapDriver.withOutput(new Text("id-1"), val);
-    mapDriver.runTest();
-  }
-
-  @Test
-  public void testFieldID() throws Exception {
-
-    Configuration conf = mapDriver.getConfiguration();
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "true");
-    byte[] delimiterBase64 = Base64.encodeBase64(",".getBytes());
-    conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
-    // The "id" is in a different position and has a diferent name my-id
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=bar, 1=junk, 2=my-id, 3=zen, 4 = hockey");
-    // Set the field id
-    conf.set("idField", "my-id");
-    LongWritable key = new LongWritable(0);// should be skipped
-    Text value = new Text("bar, id,junk,zen,hockey");// we skip the 0th line
-
-    mapDriver.withInput(key, value);
-    mapDriver.runTest();
-    assertEquals("Should be 0 documents", 0,
-        mapDriver.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
-    key = new LongWritable(1);
-    value = new Text("The quick brown fox, jumped, id-1, head, gretzky, extra");
-    // extra should be mapped to field_5
-    mapDriver.withInput(key, value);
-    mapDriver.withCounter(BaseHadoopIngest.Counters.DOCS_ADDED, 1);
-    LWDocumentWritable val = TestUtils
-        .createLWDocumentWritable("id-1", "bar", "The quick brown fox", "junk", "jumped", "zen",
-            "head", "hockey", "gretzky", "field_5", "extra");
-    mapDriver.withOutput(new Text("id-1"), val);
-    mapDriver.runTest();
-  }
-
-  @Test
-  public void testWithoutFieldID() throws Exception {
-
-    Configuration conf = mapDriver.getConfiguration();
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "true");
-    byte[] delimiterBase64 = Base64.encodeBase64(",".getBytes());
-    conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
-    // The "id" is in a different position
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=bar, 1=id, 2=junk, 3=zen, 4 = hockey");
-    // Set another field to be the id
-    conf.set("idField", "junk");
-
-    LongWritable key = new LongWritable(0);// should be skipped
-    Text value = new Text("bar, id,junk,zen,hockey");// we skip the 0th line
-
-    mapDriver.withInput(key, value);
-    mapDriver.runTest();
-    assertEquals("Should be 0 documents", 0,
-        mapDriver.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
-    key = new LongWritable(1);
-    value = new Text("The quick brown fox, id-1, jumped, head, gretzky, extra");
-    // extra should be mapped to field_5
-    mapDriver.withInput(key, value);
-    mapDriver.withCounter(BaseHadoopIngest.Counters.DOCS_ADDED, 1);
-    LWDocumentWritable val = TestUtils
-        .createLWDocumentWritable("jumped", "bar", "The quick brown fox", "id", "id-1", "zen",
-            "head", "hockey", "gretzky", "field_5", "extra");
-    mapDriver.withOutput(new Text("jumped"), val);
-    mapDriver.runTest();
-  }
-
-  @Test
-  public void testOptions() throws Exception {
-
-    Configuration conf = mapDriver.getConfiguration();
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=bar, 2=junk , 3 = zen ,   4 = hockey");
-    byte[] delimiterBase64 = Base64.encodeBase64("|".getBytes());
-    conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "false");
-
-    LongWritable key = new LongWritable(0);// not skipped
-    Text value = new Text("id-0|bar|junk|zen|hockey");
-    mapDriver.withInput(key, value);
-    mapDriver.withCounter(BaseHadoopIngest.Counters.DOCS_ADDED, 1);
-
-    LWDocumentWritable val = TestUtils
-        .createLWDocumentWritable("id-0", "bar", "bar", "junk", "junk", "zen", "zen", "hockey",
-            "hockey");
-    mapDriver.withOutput(new Text("id-0"), val);
-    mapDriver.runTest();
-
-
-    key = new LongWritable(1);
-    value = new Text("id-1|The quick brown fox|jumped|head|gretzky|extra");
-    // extra should be mapped to field_5
-    mapDriver.withInput(key, value);
-    val = TestUtils
-        .createLWDocumentWritable("id-1", "bar", "The quick brown fox", "junk", "jumped", "zen",
-            "head", "hockey", "gretzky", "field_5", "extra");
-    mapDriver.withOutput(new Text("id-1"), val);
-    mapDriver.resetExpectedCounters();
-    mapDriver.runTest();
-    // TODO: check fields
-  }
-
-  @Test
-  public void testVariations() throws Exception {
-    Configuration conf = mapDriver.getConfiguration();
-    conf.clear();
-    conf.set("io.serializations", "com.lucidworks.hadoop.io.impl.LWMockSerealization");
-    conf.set(ZK_CONNECT, "localhost:0000");
-    conf.set("idField", "id");
-    // no collection set
-    LongWritable key = new LongWritable(0);// not skipped
-    Text value = new Text("id-0|bar|junk|zen|hockey");
-    mapDriver.withInput(key, value);
-    try {
-      List<Pair<Text, LWDocumentWritable>> run = mapDriver.run();
-      Assert.fail();
-    } catch (Exception e) {
-      // expected
+        runJobSuccessfully(job, jobInput, 1);
+        assertEquals("Should be 1 documents", 1, job.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
+        final List<String> documentLines = getJobResults(1);
+        final String expectedDocStr = createExpectedDocStrWithFields("id-1", "id", "id-1",
+                "bar", "The quick brown fox",
+                "junk", "jumped",
+                "zen", "head",
+                "hockey", "gretzky",
+                "field_5", "extra");
+        assertEquals(expectedDocStr, documentLines.get(0));
     }
-    conf.set(COLLECTION, "foo");
-    conf.set(CSVIngestMapper.CSV_DELIMITER, "|");
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "false");
-    // no field mapping
-    List<Pair<Text, LWDocumentWritable>> run = mapDriver.run();
-    Assert.assertEquals(1, run.size());
-    Pair<Text, LWDocumentWritable> pair = run.get(0);
-    LWDocument doc = pair.getSecond().getLWDocument();
-    Assert.assertNotNull(doc);
-    // TODO: check fields
 
-  }
+    @Test
+    public void testLWS592() throws Exception {
+        // Input has ctrl+A delimiters
+        jobInput.add("idbarjunk"); // Skipped because of first-line-ignore setting
+        jobInput.add("id-1The quick brown foxhead");
 
-  @Test
-  public void testStrategy() throws Exception {
-    Configuration conf = mapDriver.getConfiguration();
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "false");
-    conf.set(CSVIngestMapper.CSV_DELIMITER, ",");
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=count,2=body, 3=title,4=footer");
-    conf.set(CSVIngestMapper.CSV_STRATEGY, CSVIngestMapper.EXCEL_STRATEGY);
-    LongWritable key = new LongWritable(0);// not skipped
-    Text value = new Text("id-0,bar,junk,zen,hockey");
-    LWDocument doc;
-    mapDriver.withInput(key, value);
-    List<Pair<Text, LWDocumentWritable>> run = mapDriver.run(false);
-    Assert.assertEquals(1, run.size());
-    doc = run.get(0).getSecond().getLWDocument();
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        byte[] delimiterBase64 = Base64.encodeBase64("\u0001".getBytes());
+        conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
+        conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=bar,2=junk");
 
-    Assert.assertNotNull(doc);
-    // TODO: check fields
-  }
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        final List<String> results = runJobSuccessfully(job, jobInput, 1);
 
-  @Test
-  public void testFrankenstein() throws Exception {
-    Configuration conf = mapDriver.getConfiguration();
+        assertEquals("Should be 1 document", 1, job.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
 
-    conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "true");
-    conf.set(CSVIngestMapper.CSV_DELIMITER, ",");
-    conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=count,2=body, 3=title,4=footer");
-
-    InputStream frank = CSVIngestMapperTest.class.getClassLoader()
-        .getResourceAsStream("csv" + File.separator + "frank.csv");
-    assertNotNull("frank is null", frank);
-    BufferedReader reader = new BufferedReader(new InputStreamReader(frank));
-    String line = null;
-    int i = 0;
-    while ((line = reader.readLine()) != null) {
-      String[] splits = line.split(",");
-      String id = splits[0];
-      LongWritable lineNumb = new LongWritable(i);
-      mapDriver.withInput(lineNumb, new Text(line));
-
-      i++;
+        final String expectedDocStr = createExpectedDocStrWithFields("id-1", "id", "id-1", "bar", "The quick brown fox", "junk", "head");
+        assertEquals(expectedDocStr, results.get(0));
     }
-    List<Pair<Text, LWDocumentWritable>> out = mapDriver.run(true);
-    // TODO: do some validation here, as previous attempts above aren't working
-    assertEquals(79, i);
-    assertEquals(i - 1, out.size());// we are skipping first line
-  }
+
+    @Test
+    public void testDefaultFieldId() throws Exception {
+        jobInput.add("bar, id,junk,zen,hockey"); // Skipped because of first-line-ignore setting
+        jobInput.add("The quick brown fox, id-1, jumped, head, gretzky, extra");
+
+
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=bar, 1=id, 2=junk, 3=zen, 4 = hockey");
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        final List<String> results = runJobSuccessfully(job, jobInput, 1);
+
+        assertEquals("Should be 1 document", 1, job.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
+        final String expectedDocStr = createExpectedDocStrWithFields("id-1", "id", "id-1",
+                "bar", "The quick brown fox",
+                "junk", "jumped",
+                "zen", "head",
+                "hockey", "gretzky",
+                "field_5", "extra");
+        assertEquals(expectedDocStr, results.get(0));
+    }
+
+    @Test
+    public void testFieldId() throws Exception {
+        jobInput.add("bar, id,junk,zen,hockey"); // Skipped because of first line ignore
+        jobInput.add("The quick brown fox, jumped, id-1, head, gretzky, extra");
+
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        // The "id" is in a different position and has a diferent name my-id
+        conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=bar, 1=junk, 2=my-id, 3=zen, 4 = hockey");
+        conf.set("idField", "my-id");
+
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        final List<String> results = runJobSuccessfully(job, jobInput, 1);
+
+        assertEquals("Should be 1 document", 1, job.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
+        final String doc = results.get(0);
+        final String expectedDocStr = createExpectedDocStrWithFields("id-1","id", "id-1",
+                "bar", "The quick brown fox",
+                "junk", "jumped",
+                "zen", "head",
+                "hockey", "gretzky",
+                "field_5", "extra");
+        assertEquals(expectedDocStr, doc);
+    }
+
+    @Test
+    public void testWithoutFieldId() throws Exception {
+        jobInput.add("bar, id,junk,zen,hockey");// we skip the 0th line
+        jobInput.add("The quick brown fox, id-1, jumped, head, gretzky, extra");
+
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        // The "id" is in a different position
+        conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=bar, 1=id, 2=junk, 3=zen, 4 = hockey");
+        // Set another field to be the id
+        conf.set("idField", "junk");
+
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        final List<String> results = runJobSuccessfully(job, jobInput, 1);
+
+        assertEquals("Should be 1 document", 1, job.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
+        final String doc = results.get(0);
+        final String expectedDocStr = createExpectedDocStrWithFields("jumped","id", "jumped",
+                "bar", "The quick brown fox",
+                "zen", "head",
+                "hockey", "gretzky",
+                "field_5", "extra");
+        assertEquals(expectedDocStr, doc);
+    }
+
+    @Test
+    public void testOptions() throws Exception {
+        jobInput.add("id-0|bar|junk|zen|hockey");
+        jobInput.add("id-1|The quick brown fox|jumped|head|gretzky|extra");
+
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        byte[] delimiterBase64 = Base64.encodeBase64("|".getBytes());
+        conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
+        conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "false");
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        final List<String> results = runJobSuccessfully(job, jobInput, 2);
+
+        assertEquals("Should be 2 documents", 2, job.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
+        final String doc1 = results.get(0);
+        final String doc2 = results.get(1);
+
+        final String expectedDoc1Str = createExpectedDocStrWithFields("id-0", "id", "id-0", "bar", "bar", "junk", "junk", "zen", "zen", "hockey",
+                "hockey");
+        assertEquals(expectedDoc1Str, doc1);
+
+        final String expectedDoc2Str = createExpectedDocStrWithFields("id-1", "id", "id-1", "bar", "The quick brown fox", "junk", "jumped", "zen",
+                "head", "hockey", "gretzky", "field_5", "extra");
+        assertEquals(expectedDoc2Str, doc2);
+    }
+
+    @Test
+    public void testJobFailsWithoutCollection() throws Exception {
+        jobInput.add("id,bar,junk,zen,hockey"); // Skipped because of first line ignore setting
+        jobInput.add("id-1, The quick brown fox, jumped, head, gretzky, extra");
+        withJobInput(jobInput);
+
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        conf.unset(COLLECTION);
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        job.waitForCompletion(true);
+
+        assertFalse(job.isSuccessful());
+    }
+
+    @Test
+    public void testStrategy() throws Exception {
+        jobInput.add("id-0,bar,junk,zen,hockey");
+
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "false");
+        conf.set(CSVIngestMapper.CSV_DELIMITER, ",");
+        conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=count,2=body, 3=title,4=footer");
+        conf.set(CSVIngestMapper.CSV_STRATEGY, CSVIngestMapper.EXCEL_STRATEGY);
+
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        final List<String> results = runJobSuccessfully(job, jobInput, 1);
+
+        final String expectedDocStr = createExpectedDocStrWithFields("id-0", "id", "id-0", "count", "bar", "body", "junk", "title", "zen", "footer", "hockey");
+        assertEquals(expectedDocStr, results.get(0));
+    }
+
+    @Test
+    public void testFrankenstein() throws Exception {
+        final int numLines = addFrankensteinDataToJobInput();
+        final int expectedDocuments = numLines - 1;  // We ignore the first line as a comment
+
+        Configuration conf = getDefaultCSVMapperConfiguration();
+        conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=count,2=body, 3=title,4=footer");
+
+        Job job = createJobBasedOnConfiguration(conf, CSVIngestMapper.class);
+        final List<String> results = runJobSuccessfully(job, jobInput, expectedDocuments);
+
+        assertEquals("Should be " + expectedDocuments + " documents", expectedDocuments,
+                job.getCounters().findCounter(BaseHadoopIngest.Counters.DOCS_ADDED).getValue());
+    }
+
+    private int addFrankensteinDataToJobInput() throws Exception {
+        InputStream frank = CSVIngestMapperTest.class.getClassLoader()
+                .getResourceAsStream("csv" + File.separator + "frank.csv");
+        assertNotNull("frank is null", frank);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(frank));
+        String line = null;
+        int i = 0;
+        while ((line = reader.readLine()) != null) {
+            String[] splits = line.split(",");
+            String id = splits[0];
+            LongWritable lineNumb = new LongWritable(i);
+            jobInput.add(line);
+            i++;
+        }
+
+        return i;
+    }
+
+    private Configuration getDefaultCSVMapperConfiguration() {
+        Configuration conf = getBaseConfiguration();
+        conf.set(CSVIngestMapper.CSV_IGNORE_FIRST_LINE_COMMENT, "true");
+        byte[] delimiterBase64 = Base64.encodeBase64(",".getBytes());
+        conf.set(CSVIngestMapper.CSV_DELIMITER, new String(delimiterBase64));
+        conf.set(CSVIngestMapper.CSV_FIELD_MAPPING, "0=id,1=bar, 2=junk , 3 = zen ,   4 = hockey");
+        conf.set(COLLECTION, "collection");
+        conf.set(ZK_CONNECT, "localhost:0000");
+        conf.set("idField", "id");
+
+        return conf;
+    }
 }

--- a/solr-hadoop-core/src/test/resources/log4j2.xml
+++ b/solr-hadoop-core/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Prior ot this commit, CSVIngestMapperTest used the 'mrunit' project for
its MR/Hadoop logic.  However, mrunit is a defunct project and will not
suppoprt recent versions of Hadoop, such as Hadoop 3.

This commit changes the first of several tests over to using an
in-memory Hadoop cluster (hadoop-minicluster) instead.  This allows us
to test the same logic, and is also more faithful to a production
environment than mrunit was.