### PR TITLE
Fix accidental compilation error

### DIFF
--- a/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/BaseMiniClusterTestCase.java
+++ b/solr-hadoop-core/src/test/java/com/lucidworks/hadoop/ingest/BaseMiniClusterTestCase.java
@@ -138,6 +138,11 @@ public class BaseMiniClusterTestCase {
         out.close();
     }
 
+    protected void useAlternativeInputPath(String altInputPath) throws Exception {
+        INPUT_DIRECTORY_PATH = new Path(altInputPath);
+        fs.mkdirs(INPUT_DIRECTORY_PATH);
+    }
+
     protected Path copyLocalResourceToHdfs(String localPath, String remoteFilename) throws Exception {
         return copyLocalFileToHdfs(localPath, RESOURCE_DIRECTORY_PATH, remoteFilename);
     }


### PR DESCRIPTION
While cleaning up a previous commit I had accidentally introduced a
compile error by removing a method I thought was unused.  This commit
adds that method back in to fix the build.